### PR TITLE
Could com.mossle:lemon:1.12.0 drop off redundant dependencies?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,9 +109,6 @@
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
     </dependency><dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
-    </dependency><dependency>
       <groupId>com.github.inspektr</groupId>
       <artifactId>inspektr-support-spring</artifactId>
     </dependency><dependency>


### PR DESCRIPTION
Hi! I found the pom file of project **_com.mossle:lemon:1.12.0_** introduced **_126_** dependencies. However, among them, **_1_** library are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
javax.mail:mail:jar:1.4.7:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_javax.mail:mail:jar:1.4.7:compile_** incorporates an incompatible license CDDL (CDDL cannot be used by the project with license The Apache Software License, Version 2.0). As such, I suggest a refactoring operation for **_com.mossle:lemon:1.12.0_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.mossle:lemon:1.12.0_**’s maven tests.

Best regards